### PR TITLE
Fixes

### DIFF
--- a/res/ly-openrc
+++ b/res/ly-openrc
@@ -1,4 +1,4 @@
-#! /sbin/openrc-run
+#!/sbin/openrc-run
 
 name="ly"
 description="TUI Display Manager"
@@ -13,14 +13,14 @@ if [ -x /sbin/getty ] || [ -x /bin/getty ];
 then
     # busybox
     commandB="/sbin/getty"
-elif [ -x /sbin/getty ] || [ -x /bin/agetty ];
+elif [ -x /sbin/agetty ] || [ -x /bin/agetty ];
 then
     # util-linux
     commandUL="/sbin/agetty"
 fi
 
 ## Get the tty from the conf file
-CONFTTY=$(cat /etc/ly/config.ini | grep tty | grep -v '#' | sed -e 's/tty = //' | sed -e 's/ //')
+CONFTTY=$(cat /etc/ly/config.ini | sed -n 's/^tty.*=[^1-9]*// p')
 
 ## The execution vars
 # If CONFTTY is empty then default to 2
@@ -29,7 +29,7 @@ TERM=linux
 BAUD=38400
 # If we don't have getty then we should have agetty
 command=${commandB:-$commandUL}
-command_args_foreground="-nl /usr/bin/ly ${TTY} ${BAUD} ${TERM}"
+command_args_foreground="-nl /usr/bin/ly $TTY $BAUD $TERM"
 
 depend() {
          after agetty


### PR DESCRIPTION
Fixed typo in line 16: /sbin/getty > /sbin/agetty
Better CONFTTY command
Change ${var} to just $var in line 32: The script wasn't working, so I removed these braces and the script magically started working, not sure what's happening here.